### PR TITLE
fixing typo with emptyDirs method

### DIFF
--- a/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/Kubernetes.groovy
+++ b/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/Kubernetes.groovy
@@ -107,7 +107,7 @@ class Kubernetes implements Serializable {
 
         public Pod withEmptyDir(String mountPath, String medium) {
             Map<String, String> newEmptyDirs = new HashMap<>(emptyDirs)
-            newEmptyDirs.put(emptyDir, medium)
+            newEmptyDirs.put(mountPath, medium)
             return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, newEmptyDirs, env)
         }
 


### PR DESCRIPTION
It appears the `withEmptyDir` method is broken due to a typo and attempting to use either signature results in a groovy script error. I've fixed the typo and it works for me now.