### PR TITLE
updating all project url attributes in pom.xml to point to wiki page,…

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -27,6 +27,7 @@
     <artifactId>kubernetes-pipeline-aggregator</artifactId>
     <name>Kubernetes :: Pipeline :: Aggregator</name>
     <packaging>hpi</packaging>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Pipeline+Plugin</url>
 
     <dependencies>
         <!-- Internal Deps -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,7 @@
     <artifactId>kubernetes-pipeline-core</artifactId>
     <packaging>jar</packaging>
     <name>Kubernetes :: Pipeline :: Core</name>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Pipeline+Plugin</url>
 
     <dependencies>
         <dependency>

--- a/devops-steps/pom.xml
+++ b/devops-steps/pom.xml
@@ -27,6 +27,7 @@
     <artifactId>kubernetes-pipeline-devops-steps</artifactId>
     <name>Kubernetes :: Pipeline :: DevOps Steps</name>
     <packaging>hpi</packaging>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Pipeline+Plugin</url>
 
     <dependencies>
         <dependency>

--- a/kubernetes-steps/pom.xml
+++ b/kubernetes-steps/pom.xml
@@ -27,6 +27,7 @@
     <artifactId>kubernetes-pipeline-steps</artifactId>
     <name>Kubernetes :: Pipeline :: Kubernetes Steps</name>
     <packaging>hpi</packaging>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Pipeline+Plugin</url>
 
     <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <description>Use Docker Images and Kubernetes Pods from pipeline.</description>
     <packaging>pom</packaging>
 
-    <url>http://fabric8.io/</url>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Pipeline+Plugin</url>
     <inceptionYear>2015</inceptionYear>
 
     <organization>


### PR DESCRIPTION
… should address HOSTING-113

https://issues.jenkins-ci.org/browse/HOSTING-113

```Please note that due to the missing wiki page reference in pom.xml (of each hpi packaged artifact), the plugin(s) is not available for download. (Or more precisely, it is listed in the stable versioned update sites for technical reasons, but the download URL is dead).```

Pointing/adding these URLs should re-list these plugins on the download mirrors and allow people to install them from the plugins page in jenkins.