### PR TITLE
Fix Duration = 0 Issue in Elasticsearch

### DIFF
--- a/devops-steps/src/main/java/io/fabric8/kubernetes/pipeline/devops/elasticsearch/BuildListener.java
+++ b/devops-steps/src/main/java/io/fabric8/kubernetes/pipeline/devops/elasticsearch/BuildListener.java
@@ -68,7 +68,10 @@ public class BuildListener extends RunListener<Run> {
         }
 
         final BuildDTO build = new BuildDTO();
-        build.setDuration(run.getDuration());
+        
+        long duration = System.currentTimeMillis() - run.getStartTimeInMillis();
+        build.setDuration(duration);
+        
         build.setApp(job.getFullName());
         Result result = run.getResult();
         if (result != null) {


### PR DESCRIPTION
Hi, I realized that the duration field is always 0 when an event is published to Kibana. 
After reviewing the code, I had the feeling that the event is published when the build is not finally finished, whereas the duration is only set at the very end of the build.