### PR TITLE
Use cluster volumes to share jenkins workspace

### DIFF
--- a/kubernetes-steps/readme.md
+++ b/kubernetes-steps/readme.md
@@ -54,6 +54,13 @@ This also supports specifying the medium (e.g. "Memory")
         sh 'mvn clean install'
     }                
     
+#### Using volume claim mounts
+    
+    kubernetes.pod('buildpod').withImage('maven').withVolumeClaimMount('/path/on/container', 'volume-claim-name').inside {      
+        git 'https://github.com/fabric8io/kubernetes-pipeline.git'
+        sh 'mvn clean install'
+    }  
+      
 ### Using privileged containers
 
     kubernetes.pod('buildpod').withImage('maven').withPrivileged(true).inside {      

--- a/kubernetes-steps/src/main/java/io/fabric8/kubernetes/pipeline/WithPodStep.java
+++ b/kubernetes-steps/src/main/java/io/fabric8/kubernetes/pipeline/WithPodStep.java
@@ -37,10 +37,11 @@ public class WithPodStep extends AbstractStepImpl implements Serializable {
     private final Map secrets;
     private final Map hostPathMounts;
     private final Map emptyDirs;
+    private final Map volumeClaims;
     private final Map env;
 
     @DataBoundConstructor
-    public WithPodStep(String name, String image, String serviceAccount, Boolean privileged, Map secrets, Map hostPathMounts, Map emptyDirs, Map env) {
+    public WithPodStep(String name, String image, String serviceAccount, Boolean privileged, Map secrets, Map hostPathMounts, Map emptyDirs, Map volumeClaims, Map env) {
         this.name = name;
         this.image = image;
         this.serviceAccount = serviceAccount;
@@ -48,6 +49,7 @@ public class WithPodStep extends AbstractStepImpl implements Serializable {
         this.secrets = secrets != null ? secrets : new HashMap();
         this.hostPathMounts = hostPathMounts != null ? hostPathMounts : new HashMap();
         this.emptyDirs = emptyDirs != null ? emptyDirs : new HashMap();
+        this.volumeClaims = volumeClaims != null ? volumeClaims : new HashMap();
         this.env = env != null ? env : new HashMap();
     }
 
@@ -77,6 +79,10 @@ public class WithPodStep extends AbstractStepImpl implements Serializable {
 
     public Map getEmptyDirs() {
         return emptyDirs;
+    }
+
+    public Map getVolumeClaims() {
+        return volumeClaims;
     }
 
     public Map getEnv() {

--- a/kubernetes-steps/src/main/java/io/fabric8/kubernetes/pipeline/WithPodStepExecution.java
+++ b/kubernetes-steps/src/main/java/io/fabric8/kubernetes/pipeline/WithPodStepExecution.java
@@ -68,6 +68,7 @@ public class WithPodStepExecution extends AbstractStepExecutionImpl {
                 step.getSecrets(),
                 step.getHostPathMounts(),
                 step.getEmptyDirs(),
+                step.getVolumeClaims(),
                 workspace.getRemote(),
                 createPodEnv((step.getEnv())
                 ), "cat");

--- a/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/Kubernetes.groovy
+++ b/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/Kubernetes.groovy
@@ -38,8 +38,8 @@ class Kubernetes implements Serializable {
         }
     }
 
-    public Pod pod(String name = "jenkins-pod", String image = "", String serviceAccount = "", Boolean privileged = false, Map<String, String> secrets = new HashMap(), Map<String, String> hostPaths = new HashMap(), Map<String, String> emptyDirs = new HashMap<>(), Map<String, String> env = new HashMap<>()) {
-        return new Pod(this, name, image, serviceAccount, privileged, secrets, hostPaths, emptyDirs, env)
+    public Pod pod(String name = "jenkins-pod", String image = "", String serviceAccount = "", Boolean privileged = false, Map<String, String> secrets = new HashMap(), Map<String, String> hostPaths = new HashMap(), Map<String, String> emptyDirs = new HashMap<>(), Map<String, String> volumeClaims = new HashMap<>(), Map<String, String> env = new HashMap<>()) {
+        return new Pod(this, name, image, serviceAccount, privileged, secrets, hostPaths, emptyDirs, volumeClaims, env)
     }
 
     public Image image() {
@@ -59,9 +59,10 @@ class Kubernetes implements Serializable {
         private final Map secrets
         private final Map hostPathMounts
         private final Map emptyDirs
+        private final Map volumeClaims
         private final Map env
 
-        Pod(Kubernetes kubernetes, String name, String image, String serviceAccount, Boolean privileged, Map<String, String> secrets, Map<String, String> hostPathMounts, Map<String, String> emptyDirs, Map<String, String> env) {
+        Pod(Kubernetes kubernetes, String name, String image, String serviceAccount, Boolean privileged, Map<String, String> secrets, Map<String, String> hostPathMounts, Map<String, String> emptyDirs, Map<String, String> volumeClaims, Map<String, String> env) {
             this.kubernetes = kubernetes
             this.name = name
             this.image = image
@@ -70,35 +71,36 @@ class Kubernetes implements Serializable {
             this.secrets = secrets
             this.hostPathMounts = hostPathMounts
             this.emptyDirs = emptyDirs
+            this.volumeClaims = volumeClaims
             this.env = env
         }
 
         public Pod withName(String name) {
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, volumeClaims, env)
         }
 
         public Pod withImage(String image) {
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, volumeClaims, env)
         }
 
         public Pod withServiceAccount(String serviceAccount) {
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, volumeClaims, env)
         }
 
         public Pod withPrivileged(Boolean privileged) {
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, volumeClaims, env)
         }
 
         public Pod withSecret(String secretName, String mountPath) {
             Map<String, String> newSecrets = new HashMap<>(secrets)
             newSecrets.put(secretName, mountPath)
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, newSecrets, hostPathMounts, emptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, newSecrets, hostPathMounts, emptyDirs, volumeClaims, env)
         }
 
         public Pod withHostPathMount(String hostPath, String mountPath) {
             Map<String, String> newHostPathMounts = new HashMap<>(hostPathMounts)
             newHostPathMounts.put(hostPath, mountPath)
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, newHostPathMounts, emptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, newHostPathMounts, emptyDirs, volumeClaims, env)
         }
 
         public Pod withEmptyDir(String mountPath) {
@@ -108,18 +110,24 @@ class Kubernetes implements Serializable {
         public Pod withEmptyDir(String mountPath, String medium) {
             Map<String, String> newEmptyDirs = new HashMap<>(emptyDirs)
             newEmptyDirs.put(mountPath, medium)
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, newEmptyDirs, env)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, newEmptyDirs, volumeClaims, env)
+        }
+
+        public Pod withVolumeClaim(String mountPath, String medium) {
+            Map<String, String> newVolumeClaims = new HashMap<>(emptyDirs)
+            newVolumeClaims.put(mountPath, medium)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, newVolumeClaims, env)
         }
 
         public Pod withEnvVar(String key, String value) {
             Map<String, String> newEnv = new HashMap<>(env)
             newEnv.put(key, value)
-            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, newEnv)
+            return new Pod(kubernetes, name, image, serviceAccount, privileged, secrets, hostPathMounts, emptyDirs, volumeClaims, newEnv)
         }
 
         public <V> V inside(Closure<V> body) {
             kubernetes.node {
-                kubernetes.script.withPod(name: name, image: image, serviceAccount: serviceAccount, privileged: privileged, secrets: secrets, hostPathMounts: hostPathMounts, emptyDirs: emptyDirs, env: env) {
+                kubernetes.script.withPod(name: name, image: image, serviceAccount: serviceAccount, privileged: privileged, secrets: secrets, hostPathMounts: hostPathMounts, emptyDirs: emptyDirs, volumeClaims: volumeClaims, env: env) {
                     body()
                 }
             }
@@ -176,7 +184,7 @@ class Kubernetes implements Serializable {
         }
 
         Pod toPod() {
-            return new Pod(kubernetes, "jenkins-buildpod", name, "", false, new HashMap<String, String>(), new HashMap<String, String>(), new HashMap<String, String>(), new HashMap<String, String>())
+            return new Pod(kubernetes, "jenkins-buildpod", name, "", false, new HashMap<String, String>(), new HashMap<String, String>(), new HashMap<String, String>(), new HashMap<String, String>(), new HashMap<String, String>())
         }
 
 

--- a/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/WithPodStep/config.jelly
+++ b/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/WithPodStep/config.jelly
@@ -31,5 +31,9 @@
 			<f:repeatableHeteroProperty field="hostPathMounts" hasHeader="true" addCaption="Add Empty Dir"
 				deleteCaption="Delete Empty Dir"/>
 		</f:entry>
+		<f:entry title="VolumeClaim Mounts" description="A list of Volume Claim Mounts (Mount Path -> Volume Claim Name)">
+			<f:repeatableHeteroProperty field="volumeClaimMounts" hasHeader="true" addCaption="Add Volume Claim"
+				deleteCaption="Delete Volume Claim"/>
+		</f:entry>
 	</f:advanced>
 </j:jelly>

--- a/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/WithPodStep/help-volumeClaims.html
+++ b/kubernetes-steps/src/main/resources/io/fabric8/kubernetes/pipeline/WithPodStep/help-volumeClaims.html
@@ -1,0 +1,17 @@
+The <!--
+  ~ Copyright (C) 2015 Original Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+The list of volume claim mounts. These mounts are passed in the form of key/value pairs, where key represents the mount path, value the volume claim name.


### PR DESCRIPTION
We are running several jenkins instances in one k8s cluster. The jenkins pods need to share the workspace with the build pods. As this is a multinode cluster it is not feasible to use the hostDir volumes mechanism in the current codebase for this purpose. 

All of our jenkins instances have their workspace located on a cluster volume. To share that cluster volume with the build pods, it was necessary to add the ability to mount k8s volume claims in the pod and remove the implicit hostDir mount in KubernetesFacade.

It would be great if you can take a look, I am open to any suggestion. :)