### PR TITLE
[JENKINS-49506] Whitelisting classes used by BuildImageStepExecution.BuildImageTask

### DIFF
--- a/kubernetes-steps/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/kubernetes-steps/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,3 @@
+io.fabric8.docker.api.model.ImageInspect
+io.fabric8.docker.api.model.Config
+io.fabric8.docker.api.model.GraphDriverData


### PR DESCRIPTION
Compatibility with https://github.com/jenkinsci/jenkins/pull/3120. Better would be to return plain types if possible.

BTW `BuildImageStepExecution` is a `AbstractSynchronousStepExecution` which is wrong. It should be a `SynchronousNonBlockingStepExecution`, as its `run` method can block on the network.

@reviewbybees