### PR TITLE
fixes [JENKINS-52224] service and route names issue

### DIFF
--- a/devops-steps/pom.xml
+++ b/devops-steps/pom.xml
@@ -137,6 +137,12 @@
             <artifactId>pipeline-stage-step</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.18.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/devops-steps/src/main/java/io/fabric8/kubernetes/pipeline/devops/ApplyStepExecution.java
+++ b/devops-steps/src/main/java/io/fabric8/kubernetes/pipeline/devops/ApplyStepExecution.java
@@ -53,13 +53,7 @@ import io.fabric8.kubernetes.pipeline.devops.elasticsearch.ElasticsearchClient;
 import io.fabric8.kubernetes.pipeline.devops.elasticsearch.JsonUtils;
 import io.fabric8.kubernetes.pipeline.devops.git.GitConfig;
 import io.fabric8.kubernetes.pipeline.devops.git.GitInfoCallback;
-import io.fabric8.openshift.api.model.Build;
-import io.fabric8.openshift.api.model.BuildFluent;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.api.model.DoneableBuild;
-import io.fabric8.openshift.api.model.Project;
-import io.fabric8.openshift.api.model.ProjectList;
-import io.fabric8.openshift.api.model.Template;
+import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftAPIGroups;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -86,15 +80,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -102,6 +88,8 @@ import java.util.regex.Pattern;
 import static io.fabric8.utils.PropertiesHelper.toMap;
 
 public class ApplyStepExecution extends AbstractSynchronousStepExecution<List<HasMetadata>> {
+
+    private final ServiceResourceUtil serviceFixUtil = new ServiceResourceUtil();
 
     @Inject
     private transient ApplyStep step;
@@ -128,7 +116,7 @@ public class ApplyStepExecution extends AbstractSynchronousStepExecution<List<Ha
     private transient String buildConfigName;
     private transient String buildConfigNamespace;
     private transient String buildName;
-    
+
     @Override
     public List<HasMetadata> run() throws Exception {
         String environment = step.getEnvironment();
@@ -203,6 +191,7 @@ public class ApplyStepExecution extends AbstractSynchronousStepExecution<List<Ha
             Map<String,String> deploymentVersions = new HashMap<>();
             List<Service> services = new ArrayList<>();
             //Apply all items
+            serviceFixUtil.patchServiceName(entities);
             for (HasMetadata entity : entities) {
                 listener.getLogger().println("Applying " + KubernetesHelper.getKind(entity) + " name: " + KubernetesHelper.getKind(entity) + " data: " + entity);
                 if (entity instanceof Pod) {
@@ -216,6 +205,7 @@ public class ApplyStepExecution extends AbstractSynchronousStepExecution<List<Ha
                     Service service = (Service) entity;
                     services.add(service);
                     controller.applyService(service, fileName);
+
                 } else if (entity instanceof ReplicationController) {
                     ReplicationController replicationController = (ReplicationController) entity;
                     controller.applyReplicationController(replicationController, fileName);

--- a/devops-steps/src/main/java/io/fabric8/kubernetes/pipeline/devops/ServiceResourceUtil.java
+++ b/devops-steps/src/main/java/io/fabric8/kubernetes/pipeline/devops/ServiceResourceUtil.java
@@ -1,0 +1,112 @@
+package io.fabric8.kubernetes.pipeline.devops;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.openshift.api.model.Route;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ServiceResourceUtil implements Serializable {
+
+    private static final String SERVICE_NAME_REGEX = "[a-z]([-a-z0-9]*[a-z0-9])?";
+    public static final int SERVICE_NAME_MAX_LENGTH = 58;
+    public static final String SERVICE_NAME_PREFIX = "svc-";
+    public static final String K8S_PIPELINE_SERVICE_PATCH = "K8S_PIPELINE_SERVICE_PATCH";
+
+    private final Function<HasMetadata, String> resourceKeyMapper = (r) -> r.getMetadata().getName();
+
+    public void patchServiceName(Set<HasMetadata> entities) {
+        if(isPatchingDisabled()) {
+            return;
+        }
+
+        Map<String, Service> services =  patchServiceIfInvalidName(entities);
+        Map<String, Route> routes = patchRouteWithService(entities, services);
+
+        replace(services, entities);
+        replace(routes, entities);
+    }
+
+    private boolean isPatchingDisabled() {
+        return System.getenv(K8S_PIPELINE_SERVICE_PATCH) == null ||
+                System.getenv(K8S_PIPELINE_SERVICE_PATCH).isEmpty() ||
+                !System.getenv("K8S_PIPELINE_SERVICE_PATCH").equalsIgnoreCase("enabled");
+    }
+
+    private Map<String, Service> patchServiceIfInvalidName(Set<HasMetadata> resources) {
+
+        Predicate<HasMetadata> invalidService = (r) -> r instanceof Service && hasInvalidDNS((Service) r);
+        Function<HasMetadata, Service> patchedService = (r) -> sanitizeServiceName((Service) r);
+
+        Map<String, Service> patchedServices = resources.stream()
+                .filter(invalidService)
+                .collect(Collectors.toMap(resourceKeyMapper, patchedService));
+
+        return patchedServices;
+    }
+
+    private Map<String, Route> patchRouteWithService(Set<HasMetadata> resources, Map<String, Service> services) {
+
+        Predicate<HasMetadata> routeToUpdate = (r) -> r instanceof Route && services.get(serviceNameFromRoute((Route) r)) != null;
+        Function<HasMetadata, Route> patchedRoute = (r) -> updateRoute((Route) r, services.get(serviceNameFromRoute((Route) r)));
+
+        Map<String, Route> patchedRoutes = resources.stream()
+                                .filter(routeToUpdate)
+                                .collect(Collectors.toMap(resourceKeyMapper, patchedRoute));
+
+        return patchedRoutes;
+    }
+
+    public boolean hasInvalidDNS(Service service) {
+        if (service.getMetadata() != null && service.getMetadata().getName() != null)
+            return !(Pattern.matches(SERVICE_NAME_REGEX, service.getMetadata().getName()));
+        else
+            return false;
+    }
+
+    private Service sanitizeServiceName(Service service) {
+        String serviceName = service.getMetadata().getName();
+        service.getMetadata().setName(SERVICE_NAME_PREFIX + truncate(serviceName).toLowerCase());
+        return service;
+    }
+
+    private String serviceNameFromRoute(Route route) {
+        if(route.getSpec() != null && route.getSpec().getTo() != null && route.getSpec().getTo().getKind().equals("Service")) {
+            return route.getSpec().getTo().getName();
+        } else {
+            return null;
+        }
+    }
+
+    private Route updateRoute(Route route, Service service) {
+        route.getSpec().getTo().setName(service.getMetadata().getName());
+        return route;
+    }
+
+    private String truncate(String name) {
+        if (name.length() > SERVICE_NAME_MAX_LENGTH) {
+            return name.substring(0, SERVICE_NAME_MAX_LENGTH);
+        } else {
+            return name;
+        }
+    }
+
+    private void replace(Map<String, ? extends HasMetadata> patchedResources, Set<HasMetadata> originalResources) {
+
+        originalResources = originalResources.stream()
+                    .filter(r -> patchedResources.get(r.getMetadata().getName()) == null)
+                    .collect(Collectors.toSet());
+
+        originalResources.addAll(patchedResources
+                    .entrySet().stream()
+                    .map(Map.Entry::getValue)
+                    .collect(Collectors.toSet()));
+    }
+
+}

--- a/devops-steps/src/test/java/io/fabric8/kubernetes/pipeline/devops/ServiceResourceUtilTest.java
+++ b/devops-steps/src/test/java/io/fabric8/kubernetes/pipeline/devops/ServiceResourceUtilTest.java
@@ -1,0 +1,149 @@
+package io.fabric8.kubernetes.pipeline.devops;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.openshift.api.model.Route;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.io.InputStream;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Created by hshinde on 6/26/18.
+ */
+public class ServiceResourceUtilTest {
+
+    @Rule
+    public final EnvironmentVariables envVars = new EnvironmentVariables();
+
+    @Test
+    public void patchServiceNameAndRoute() throws Exception {
+        // GIVEN
+        envVars.set(ServiceResourceUtil.K8S_PIPELINE_SERVICE_PATCH, "enabled");
+        Set<HasMetadata> entities = getEntitiesFromResource("/services/invalidservice1.yaml");
+        ServiceResourceUtil util = new ServiceResourceUtil();
+
+        // WHEN
+        util.patchServiceName(entities);
+
+        // THEN
+        HasMetadata service = getKind(entities, "Service");
+        Route route = (Route) getKind(entities, "Route");
+        assertEquals(2, entities.size());
+        assertFalse(util.hasInvalidDNS((Service) service));
+        assertEquals(service.getMetadata().getName(), route.getSpec().getTo().getName());
+    }
+
+    @Test
+    public void patchServiceNameOnlyIfNoRoute() throws Exception {
+        //GIVEN
+        envVars.set(ServiceResourceUtil.K8S_PIPELINE_SERVICE_PATCH, "enabled");
+        Set<HasMetadata> entities = getEntitiesFromResource("/services/invalidservice2.yaml");
+        ServiceResourceUtil util = new ServiceResourceUtil();
+
+        // WHEN
+        util.patchServiceName(entities);
+
+        // THEN
+        HasMetadata service = getKind(entities, "Service");
+        assertEquals(1, entities.size());
+        assertFalse(util.hasInvalidDNS((Service) service));
+    }
+
+    @Test
+    public void patchServiceNameOnlyIfNoRouteToService() throws Exception {
+        // GIVEN
+        envVars.set(ServiceResourceUtil.K8S_PIPELINE_SERVICE_PATCH, "enabled");
+        Set<HasMetadata> entities = getEntitiesFromResource("/services/invalidservice3.yaml");
+        ServiceResourceUtil util = new ServiceResourceUtil();
+
+        // WHEN
+        util.patchServiceName(entities);
+
+        // THEN
+        HasMetadata service = getKind(entities, "Service");
+        Route route = (Route) getKind(entities, "Route");
+        assertEquals(2, entities.size());
+        assertFalse(util.hasInvalidDNS((Service) service));
+        assertEquals("somelb", route.getSpec().getTo().getName());
+    }
+
+    @Test
+    public void dontPatchValidServiceAndRoute() throws Exception {
+        // GIVEN
+        envVars.set(ServiceResourceUtil.K8S_PIPELINE_SERVICE_PATCH, "enabled");
+        Set<HasMetadata> entities = getEntitiesFromResource("/services/validservice3.yaml");
+        ServiceResourceUtil util = new ServiceResourceUtil();
+
+        // WHEN
+        util.patchServiceName(entities);
+
+        // THEN
+        HasMetadata service = getKind(entities, "Service");
+        Route route = (Route) getKind(entities, "Route");
+        assertEquals(4, entities.size());
+        assertFalse(util.hasInvalidDNS((Service) service));
+        assertEquals("nodejs-rest-http", service.getMetadata().getName());
+        assertEquals("nodejs-rest-http", route.getSpec().getTo().getName());
+    }
+
+    @Test
+    public void dontPatchRoute() throws Exception {
+        // GIVEN
+        envVars.set(ServiceResourceUtil.K8S_PIPELINE_SERVICE_PATCH, "enabled");
+        Set<HasMetadata> entities = getEntitiesFromResource("/services/validservice4.yaml");
+        ServiceResourceUtil util = new ServiceResourceUtil();
+
+        // WHEN
+        util.patchServiceName(entities);
+
+        // THEN
+        HasMetadata service = getKind(entities, "Service");
+        Route route = (Route) getKind(entities, "Route");
+        assertEquals(3, entities.size());
+        assertNull(service);
+        assertEquals("nodejs-rest-http", route.getSpec().getTo().getName());
+    }
+
+    @Test
+    public void shouldDisablePatching() throws Exception {
+        // GIVEN
+        envVars.set(ServiceResourceUtil.K8S_PIPELINE_SERVICE_PATCH, "disabled");
+        Set<HasMetadata> entities = getEntitiesFromResource("/services/invalidservice1.yaml");
+        ServiceResourceUtil util = new ServiceResourceUtil();
+
+        // WHEN
+        util.patchServiceName(entities);
+
+        // THEN
+        HasMetadata service = getKind(entities, "Service");
+        Route route = (Route) getKind(entities, "Route");
+        assertEquals(2, entities.size());
+        assertEquals("12Nodejs-rest-http", service.getMetadata().getName());
+        assertEquals("12Nodejs-rest-http", route.getSpec().getTo().getName());
+    }
+
+    public Set<HasMetadata> getEntitiesFromResource(String resourcePath) {
+        InputStream resourceStream = getClass().getResourceAsStream(resourcePath);
+        return new DefaultKubernetesClient().load(resourceStream).get().stream().collect(Collectors.toSet());
+    }
+
+    private HasMetadata getKind(Set<HasMetadata> entities, String kind) {
+        for(HasMetadata entity : entities) {
+            if(entity.getKind().equals(kind)) {
+                return entity;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/devops-steps/src/test/resources/services/invalidservice1.yaml
+++ b/devops-steps/src/test/resources/services/invalidservice1.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: launchpad-builder
+  annotations:
+    description: This template creates a Build Configuration using an S2I builder.
+    tags: instant-app
+objects:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: 12Nodejs-rest-http
+    spec:
+      ports:
+        - protocol: TCP
+          port: 8080
+          targetPort: 8080
+      selector:
+        project: nodejs-rest-http
+        provider: nodeshift
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: nodejs-rest-http
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: 12Nodejs-rest-http

--- a/devops-steps/src/test/resources/services/invalidservice2.yaml
+++ b/devops-steps/src/test/resources/services/invalidservice2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: launchpad-builder
+  annotations:
+    description: This template creates a Build Configuration using an S2I builder.
+    tags: instant-app
+objects:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: 12Nodejs-rest-Http12Nodejs-rest-Http12Nodejs-rest-Http12Nodejs-rest-Http12Nodejs-rest-http12Nodejs-rest-Http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http12Nodejs-rest-http
+    spec:
+      ports:
+        - protocol: TCP
+          port: 8080
+          targetPort: 8080
+      selector:
+        project: nodejs-rest-http
+        provider: nodeshift
+      type: ClusterIP

--- a/devops-steps/src/test/resources/services/invalidservice3.yaml
+++ b/devops-steps/src/test/resources/services/invalidservice3.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: launchpad-builder
+  annotations:
+    description: This template creates a Build Configuration using an S2I builder.
+    tags: instant-app
+objects:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: 12Nodejs-rest-http
+    spec:
+      ports:
+        - protocol: TCP
+          port: 8080
+          targetPort: 8080
+      selector:
+        project: nodejs-rest-http
+        provider: nodeshift
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: nodejs-rest-http
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Loadbalancer
+        name: somelb

--- a/devops-steps/src/test/resources/services/validservice3.yaml
+++ b/devops-steps/src/test/resources/services/validservice3.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: launchpad-builder
+  annotations:
+    description: This template creates a Build Configuration using an S2I builder.
+    tags: instant-app
+objects:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: nodejs-rest-http
+    spec:
+      ports:
+        - protocol: TCP
+          port: 8080
+          targetPort: 8080
+      selector:
+        project: nodejs-rest-http
+        provider: nodeshift
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: nodejs-rest-http
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: nodejs-rest-http
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: runtime
+    spec:
+      tags:
+        - name: latest
+          from:
+            kind: DockerImage
+            name: 'bucharestgold/centos7-s2i-nodejs:10.x'
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      name: nodejs-rest-http
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: 'nodejs-rest-http:latest'
+      postCommit: {}
+      resources: {}
+      source:
+        git:
+          uri: '${SOURCE_REPOSITORY_URL}'
+          ref: '${SOURCE_REPOSITORY_REF}'
+        type: Git
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: 'runtime:latest'
+          incremental: true
+      triggers:
+        - github:
+            secret: '${GITHUB_WEBHOOK_SECRET}'
+          type: GitHub
+        - type: ConfigChange
+        - imageChange: {}
+          type: ImageChange
+    status:
+      lastVersion: 0

--- a/devops-steps/src/test/resources/services/validservice4.yaml
+++ b/devops-steps/src/test/resources/services/validservice4.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: launchpad-builder
+  annotations:
+    description: This template creates a Build Configuration using an S2I builder.
+    tags: instant-app
+objects:
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        project: nodejs-rest-http
+        provider: nodeshift
+        version: 2.0.0
+      name: nodejs-rest-http
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: nodejs-rest-http
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: runtime
+    spec:
+      tags:
+        - name: latest
+          from:
+            kind: DockerImage
+            name: 'bucharestgold/centos7-s2i-nodejs:10.x'
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      name: nodejs-rest-http
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: 'nodejs-rest-http:latest'
+      postCommit: {}
+      resources: {}
+      source:
+        git:
+          uri: '${SOURCE_REPOSITORY_URL}'
+          ref: '${SOURCE_REPOSITORY_REF}'
+        type: Git
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: 'runtime:latest'
+          incremental: true
+      triggers:
+        - github:
+            secret: '${GITHUB_WEBHOOK_SECRET}'
+          type: GitHub
+        - type: ConfigChange
+        - imageChange: {}
+          type: ImageChange
+    status:
+      lastVersion: 0


### PR DESCRIPTION
For most of the applications, service name is derived from application name. If service name is not adhering to valid DNS characters then `applyKubernetes` step fails to create k8s resources. To fix this issue, this patch will update(sanitize) the invalid service name by prefixing svc- and transforming all characters to small case and updates the service reference in route. This auto-patching can be enabled or disabled by setting ENV var "K8S_PIPELINE_SERVICE_PATCH" to "enabled" or "K8S_PIPELINE_SERVICE_PATCH" to "disabled" (by default its disabled)".
