### PR TITLE
[JENKINS-73124] MIME_TYPES should not be manipulated

### DIFF
--- a/core/src/test/java/org/jvnet/hudson/test/JenkinsRuleNonLocalhost.java
+++ b/core/src/test/java/org/jvnet/hudson/test/JenkinsRuleNonLocalhost.java
@@ -68,7 +68,6 @@ public class JenkinsRuleNonLocalhost extends JenkinsRule {
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
         context.addBean(new NoListenerConfiguration(context));
         server.setHandler(context);
-        context.setMimeTypes(MIME_TYPES);
         context.getSecurityHandler().setLoginService(configureUserRealm());
         context.setResourceBase(WarExploder.getExplodedDir().getPath());
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This comes from https://github.com/jenkinsci/jenkins-test-harness/pull/764 when the `MIME_TYPES` manipulation is deprecated and should be removed in order to complete the migration to Jetty 12.

It follow up the example of https://github.com/jenkinsci/kubernetes-plugin/pull/1547.

### Testing done

I ran `mvn verify` and no test failures were reported.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
